### PR TITLE
Add install support in to makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ LIB_PREFIX = $(LIB)lib
 SO_TARGET = $(LIB_PREFIX)$(LIB_BASE_NAME).so
 A_TARGET = $(LIB_PREFIX)$(LIB_BASE_NAME).a
 
+INSTALL_DIR ?= install-output
+
 EXE_DIR = $(OUT)exe
 EXE = $(EXE_DIR)/
 
@@ -91,6 +93,17 @@ build-example-executables: CPPFLAGS += -L$(LIB)
 build-example-executables: LDLIBS += -levent-machine
 build-example-executables: $(EXAMPLE_EXECUTABLES)
 .PHONY: build-examples
+
+install: all
+	install -d $(INSTALL_DIR)/bin/
+	install -d $(INSTALL_DIR)/lib/
+	install -d $(INSTALL_DIR)/include/
+	install -d $(INSTALL_DIR)/include/event-machine/
+	install -D $(SO_TARGET) $(INSTALL_DIR)/lib
+	install -D $(A_TARGET) $(INSTALL_DIR)/lib
+	install -D src/event-machine.h $(INSTALL_DIR)/include/
+	install -D src/event-machine/result.h $(INSTALL_DIR)/include/event-machine
+.PHONY: install
 
 clean: clean-objects clean-dependency-files
 .PHONY: clean


### PR DESCRIPTION
I have tried a lot of variant how to install all needed files into outputs directory. And I have came up to conclusion that I can't make some generic system without changing whole make system.
The most easy and fast way how to add manageable install target is to write target directly. In all cases I would need to set two paths anyway first which file copy and second where to copy it.
