### PR TITLE
Presents oneshot timer implementation.

### DIFF
--- a/example/timer.c
+++ b/example/timer.c
@@ -40,6 +40,11 @@ void timer_timeout(Event_timer *timer, void *data)
     printf("timer timeout\n");
 }
 
+void oneshot_timer_timeout(Event_timer *timer, void *data)
+{
+    printf("timer oneshot timeout\n");
+}
+
 int main()
 {
     struct epoll_event epoll_events[EM_DEFAULT_MAX_EVENTS];
@@ -63,8 +68,17 @@ int main()
 
     Event_timer timer;
     if (is_em_failure(event_timer_create(&em, &timer, timer_timeout, NULL))
-        || is_em_failure(event_timer_start(&timer, 1500)))
+    || is_em_failure(event_timer_start(&timer, 1500, false)))
     {
+    	perror("error: ");
+        exit(EXIT_FAILURE);
+    }
+
+    Event_timer oneshot_timer;
+    if(is_em_failure(event_timer_create(&em, &oneshot_timer, oneshot_timer_timeout, NULL))
+    || is_em_failure(event_timer_start(&oneshot_timer, 1500, true)))
+    {
+        perror("error: ");
         exit(EXIT_FAILURE);
     }
 
@@ -74,7 +88,8 @@ int main()
     }
 
     if (is_em_failure(event_timer_stop(&timer))
-        || is_em_failure(event_timer_destroy(&timer)))
+        || is_em_failure(event_timer_destroy(&timer))
+        || is_em_failure(event_timer_destroy(&oneshot_timer)))
     {
         exit(EXIT_FAILURE);
     }

--- a/src/event-timer.c
+++ b/src/event-timer.c
@@ -118,7 +118,8 @@ uint32_t event_timer_create(EM *const event_machine, Event_timer *const timer,
     return ret;
 }
 
-uint32_t event_timer_start(Event_timer *const timer, const int32_t msec)
+uint32_t event_timer_start(Event_timer *const timer, const int32_t msec,
+    const bool is_one_shot)
 {
     if_null (timer)
     {
@@ -130,11 +131,13 @@ uint32_t event_timer_start(Event_timer *const timer, const int32_t msec)
         .tv_sec = msec / 1000,
         .tv_nsec = (msec % 1000) * 1000
     };
+    struct timespec expiration_time_zero = {0, 0};
     struct itimerspec expiration =
     {
-        .it_interval = expiration_time,
+        .it_interval = is_one_shot ? expiration_time_zero : expiration_time,
         .it_value = expiration_time
     };
+    
     if_negative (timerfd_settime(TIMER_FD(timer), 0, &expiration, NULL))
     {
         return EM_ERROR_TIMERFD_SETTIME;

--- a/src/event-timer.h
+++ b/src/event-timer.h
@@ -35,13 +35,51 @@ typedef struct Event_timer_s
     Event_timer_handler callback;
 } Event_timer;
 
+/** Create and register event timer in event machine.
+*
+* Function will fill Event_timer structure and after that it register 
+* event in event machine. Passed event machine must be already 
+* initialized and passed Event_timer structure must be allocated.
+* 
+* @return ::EM_ERROR_NULL
+* @return ::EM_ERROR_TIMER_NULL
+* @return ::EM_ERROR_CALLBACK_NULL
+* @return ::EM_ERROR_BADFD
+* @return Errors returned by event_machine_add().
+* @return ::EM_SUCCESS
+* 
+*/
 uint32_t event_timer_create(EM *event_machine, Event_timer *timer,
     Event_timer_handler callback, void *data);
 
-uint32_t event_timer_start(Event_timer *timer, int32_t msec);
+/** Start timer with given periode.
+*
+* @return ::EM_ERROR_TIMER_NULL
+* @return ::EM_ERROR_TIMERFD_SETTIME
+* @return ::EM_SUCCESS
+* 
+*/
+uint32_t event_timer_start(Event_timer *timer, int32_t msec,
+    const bool one_shot);
 
+/** Stop timer.
+*
+* @return ::EM_ERROR_TIMER_NULL
+* @return ::EM_ERROR_TIMERFD_SETTIME
+* @return ::EM_SUCCESS
+* 
+*/
 uint32_t event_timer_stop(Event_timer *timer);
 
+/** Uninitialize time and set all structure parts to forbidden values.
+*
+* @return ::EM_ERROR_TIMER_NULL timer passed to function is NULL.
+* @return ::EM_ERROR_CLOSE internal file descriptor is can't be closed from
+*         some reason. This sould not happen but we need to be sure.
+* @return Errors returned by event_machine_delete().
+* @return ::EM_SUCCESS indicale all want sucessfuly
+* 
+*/
 uint32_t event_timer_destroy(Event_timer *timer);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Oneshot timer is started when kernel call timerfd_settime gets itimerspec
structure with interval set to zero.. And so oneshot timer is distinguished by
one flag passed to event_timer_start which set itimerspec structure properly.
